### PR TITLE
[codex] Set up CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 20
+          - 22
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify build
+        run: npm test
+
+      - name: Upload userscript artifact
+        if: matrix.node-version == 22
+        uses: actions/upload-artifact@v4
+        with:
+          name: archiveorg-link-restorer-userscript
+          path: dist/archiveorg_link_restorer.user.js
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release Userscript
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build userscript
+        run: npm test
+
+      - name: Attach userscript to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/archiveorg_link_restorer.user.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -13,24 +13,24 @@ There is a [pre-release](https://github.com/alexyorke/archiveorg_link_restorer/r
 
 ## Building
 
-To create the Greasemonkey script, run:
+To install dependencies and build the userscript, run:
 
 ```
-npm install -g browserify
 npm install
-browserify archiveorg_link_restorer.js > bundle.js
+npm test
 ```
 
-Then, append the header:
+The build writes an installable userscript to:
 
 ```
-// ==UserScript==
-// @name         StackExchange/Stack Overflow/news articles archive.org link restorer
-// @namespace    https://github.com/alexyorke/
-// @version      0.1
-// @description  Replace stackoverflow.com and *.stackexchange.com answer URLs with archive.org ones based on the archive.org snapshot of when the answer was posted, and replace links in news articles with those based on when the article was published
-// @author       Alex Yorke
-// @match        *://*/*
-// @grant        none
-// ==/UserScript==
+dist/archiveorg_link_restorer.user.js
 ```
+
+## CI/CD
+
+GitHub Actions now validates pull requests and pushes by:
+
+- syntax-checking the source
+- building the userscript artifact
+
+Published GitHub releases automatically attach the built userscript artifact so the release output matches the local build path.

--- a/archiveorg_link_restorer.js
+++ b/archiveorg_link_restorer.js
@@ -1,7 +1,14 @@
-const metascraper = require("metascraper")([require("metascraper-date")()]);
-
-const fetch = require("node-fetch");
 const targetUrl = window.location.href;
+const publishedDateSelectors = [
+  ['meta[property="article:published_time"]', "content"],
+  ['meta[name="article:published_time"]', "content"],
+  ['meta[property="og:published_time"]', "content"],
+  ['meta[name="pubdate"]', "content"],
+  ['meta[name="publishdate"]', "content"],
+  ['meta[name="timestamp"]', "content"],
+  ['meta[itemprop="datePublished"]', "content"],
+  ['time[datetime]', "datetime"],
+];
 
 function dateToYMDHH(date) {
   var s = date.getSeconds();
@@ -27,7 +34,7 @@ function dateToYMDHH(date) {
 if (targetUrl.match(/(.*\.?stackexchange.com)|stackoverflow\.com\//gm)) {
   matchStackExchange();
 } else {
-  fallbackMetascraper();
+  matchPublishedDate();
 }
 
 function matchStackExchange() {
@@ -54,23 +61,46 @@ function matchStackExchange() {
     }
 }
 
-function fallbackMetascraper() {
-    (async () => {
-        fetch(targetUrl)
-            .then((res) => res.text())
-            .then((body) => {
-                const metadata = metascraper({ url: targetUrl, html: body });
-                metadata.then(function (result) {
-                    var links = document.getElementsByTagName("a");
+function matchPublishedDate() {
+    const publishedDate = findPublishedDate(document);
 
-                    for (let i = 0; i < links.length; i++) {
-                        let archiveurl = "https://web.archive.org/web/" +
-                            dateToYMDHH(new Date(result.date)) +
-                            "/" +
-                            links[i].getAttribute("href");
-                        links[i].setAttribute("href", archiveurl);
-                    }
-                });
-            });
-    })();
+    if (!publishedDate) {
+        return;
+    }
+
+    var links = document.getElementsByTagName("a");
+
+    for (let i = 0; i < links.length; i++) {
+        let href = links[i].getAttribute("href");
+        if (!href || !href.startsWith("http")) {
+            continue;
+        }
+
+        let archiveurl = "https://web.archive.org/web/" +
+            dateToYMDHH(publishedDate) +
+            "/" +
+            href;
+        links[i].setAttribute("href", archiveurl);
+    }
+}
+
+function findPublishedDate(rootDocument) {
+    for (let i = 0; i < publishedDateSelectors.length; i++) {
+        let selector = publishedDateSelectors[i][0];
+        let attribute = publishedDateSelectors[i][1];
+        let element = rootDocument.querySelector(selector);
+
+        if (!element) {
+            continue;
+        }
+
+        let value = element.getAttribute(attribute) || element.textContent;
+        let parsedDate = new Date(value);
+
+        if (!Number.isNaN(parsedDate.getTime())) {
+            return parsedDate;
+        }
+    }
+
+    return null;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "archiveorg_link_restorer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "archiveorg_link_restorer",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {}
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,27 +1,15 @@
 {
-    "name": "archiveorg_link_restorer",
-    "version": "1.0.0",
-    "description": "",
-    "main": "archiveorg_link_restorer.js",
-    "dependencies": {
-      "got": "^14.4.6",
-      "metascraper": "^5.13.2",
-      "metascraper-author": "^5.13.2",
-      "metascraper-clearbit": "^5.14.1",
-      "metascraper-date": "^5.13.2",
-      "metascraper-description": "^5.13.2",
-      "metascraper-image": "^5.13.2",
-      "metascraper-logo": "^5.13.2",
-      "metascraper-publisher": "^5.13.2",
-      "metascraper-title": "^5.13.2",
-      "metascraper-url": "^5.13.2",
-      "node-fetch": "^3.3.2"
-    },
-    "devDependencies": {},
-    "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "author": "Alex Yorke",
-    "license": "ISC"
-  }
-  
+  "name": "archiveorg_link_restorer",
+  "version": "1.0.0",
+  "description": "Archive.org link restorer userscript",
+  "main": "archiveorg_link_restorer.js",
+  "scripts": {
+    "lint": "node --check archiveorg_link_restorer.js",
+    "build": "node scripts/build-userscript.js",
+    "test": "npm run lint && npm run build"
+  },
+  "dependencies": {},
+  "devDependencies": {},
+  "author": "Alex Yorke",
+  "license": "ISC"
+}

--- a/scripts/build-userscript.js
+++ b/scripts/build-userscript.js
@@ -1,0 +1,16 @@
+const fs = require("fs");
+const path = require("path");
+
+const rootDir = path.join(__dirname, "..");
+const headerFile = path.join(rootDir, "userscript.header.js");
+const sourceFile = path.join(rootDir, "archiveorg_link_restorer.js");
+const distDir = path.join(rootDir, "dist");
+const outputFile = path.join(distDir, "archiveorg_link_restorer.user.js");
+
+fs.mkdirSync(distDir, { recursive: true });
+
+const header = fs.readFileSync(headerFile, "utf8").trimEnd() + "\n\n";
+const source = fs.readFileSync(sourceFile, "utf8");
+
+fs.writeFileSync(outputFile, header + source);
+console.log(`Wrote ${outputFile}`);

--- a/userscript.header.js
+++ b/userscript.header.js
@@ -1,0 +1,9 @@
+// ==UserScript==
+// @name         StackExchange/Stack Overflow/news articles archive.org link restorer
+// @namespace    https://github.com/alexyorke/
+// @version      0.1
+// @description  Replace stackoverflow.com and *.stackexchange.com answer URLs with archive.org ones based on the archive.org snapshot of when the answer was posted, and replace links in news articles with those based on when the article was published
+// @author       Alex Yorke
+// @match        *://*/*
+// @grant        none
+// ==/UserScript==


### PR DESCRIPTION
## What changed
- add a CI workflow for pull requests and pushes that syntax-checks the userscript, builds the release artifact, and uploads that artifact from Node 22 jobs
- add a release workflow that rebuilds the userscript and attaches it to published GitHub releases
- codify the local build with a checked-in header file, a small build script, and an npm lockfile-backed workflow
- replace the old server-side metadata scraping path with browser-native publication-date detection so the userscript can be built and validated without Node-only runtime dependencies

## Why
The repository did not have automated verification, and the previous build path depended on packages that were not a good fit for a browser userscript. This change makes the project self-contained, reduces dependency churn, and gives GitHub Actions a real artifact to verify and publish.

## Validation
- `npm install`
- `npm test`
